### PR TITLE
Native build on Linux ARM

### DIFF
--- a/.github/workflows/basesystem.yml
+++ b/.github/workflows/basesystem.yml
@@ -12,8 +12,8 @@ env:
 
 jobs:
   build:
-    name: Build ${{ matrix.image.name }} on ${{ matrix.platform }}
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.image.name }} on ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
         image:
@@ -23,13 +23,13 @@ jobs:
           - {name: "latest", baseImg: "ubuntu:rolling", file: "storm-basesystem/Dockerfile"}
           - {name: "minimal_dependencies", baseImg: "ubuntu:rolling", file: "storm-basesystem/Dockerfile.minimal_dependencies"}
         platform:
-          - linux/amd64
-          - linux/arm64
+          - {name: linux/amd64, runner: "ubuntu-latest"}
+          - {name: linux/arm64, runner: "ubuntu-24.04-arm"}
     steps:
       - name: Prepare
         # Sanitize platform name
         run: |
-          platform=${{ matrix.platform }}
+          platform=${{ matrix.platform.name }}
           echo "PLATFORM=${platform//\//-}" >> $GITHUB_ENV
       - name: Docker metadata
         id: meta
@@ -38,8 +38,6 @@ jobs:
           images: ${{ env.IMAGE }}
           tags: |
             type=raw,${{ matrix.image.name }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
@@ -56,19 +54,19 @@ jobs:
           file: ${{ matrix.image.file }}
           build-args: |
             BASE_IMAGE=${{ matrix.image.baseImg }}
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.platform.name }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |
-          mkdir -p /tmp/digests/${{ matrix.image.name }}
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.image.name }}
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${{ matrix.image.name }}/${digest#sha256:}"          
+          touch "${{ runner.temp }}/digests/${{ matrix.image.name }}/${digest#sha256:}"
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.image.name }}-digests-${{ env.PLATFORM }}
-          path: /tmp/digests/${{ matrix.image.name }}/*
+          path: ${{ runner.temp }}/digests/${{ matrix.image.name }}/*
           if-no-files-found: error
           retention-days: 1
 
@@ -90,7 +88,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/digests/${{ matrix.image.name }}
+          path: ${{ runner.temp }}/digests/${{ matrix.image.name }}
           pattern: ${{ matrix.image.name }}-digests-*
           merge-multiple: true
       - name: Set up Docker Buildx
@@ -110,7 +108,7 @@ jobs:
           username: ${{ secrets.STORM_CI_DOCKER_USERNAME }}
           password: ${{ secrets.STORM_CI_DOCKER_TOKEN }}
       - name: Create manifest list and push
-        working-directory: /tmp/digests/${{ matrix.image.name }}
+        working-directory: ${{ runner.temp }}/digests/${{ matrix.image.name }}
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json}}') \
             $(printf '${{ env.IMAGE }}@sha256:%s ' *)

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -12,21 +12,21 @@ env:
 
 jobs:
   build:
-    name: Build ${{ matrix.image.name }} on ${{ matrix.platform }}
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.image.name }} on ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
         image:
           - {name: "latest", baseImg: "movesrwth/carl-storm:14.28", file: "storm-dependencies/Dockerfile"}
           - {name: "latest-debug", baseImg: "movesrwth/carl-storm:14.28-debug", file: "storm-dependencies/Dockerfile"}
         platform:
-          - linux/amd64
-          - linux/arm64
+          - {name: linux/amd64, runner: "ubuntu-latest"}
+          - {name: linux/arm64, runner: "ubuntu-24.04-arm"}
     steps:
       - name: Prepare
         # Sanitize platform name
         run: |
-          platform=${{ matrix.platform }}
+          platform=${{ matrix.platform.name }}
           echo "PLATFORM=${platform//\//-}" >> $GITHUB_ENV
       - name: Docker metadata
         id: meta
@@ -35,8 +35,6 @@ jobs:
           images: ${{ env.IMAGE }}
           tags: |
             type=raw,${{ matrix.image.name }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
@@ -53,19 +51,19 @@ jobs:
           file: ${{ matrix.image.file }}
           build-args: |
             BASE_IMAGE=${{ matrix.image.baseImg }}
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.platform.name }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |
-          mkdir -p /tmp/digests/${{ matrix.image.name }}
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.image.name }}
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${{ matrix.image.name }}/${digest#sha256:}"          
+          touch "${{ runner.temp }}/digests/${{ matrix.image.name }}/${digest#sha256:}"
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.image.name }}-digests-${{ env.PLATFORM }}
-          path: /tmp/digests/${{ matrix.image.name }}/*
+          path: ${{ runner.temp }}/digests/${{ matrix.image.name }}/*
           if-no-files-found: error
           retention-days: 1
 
@@ -84,7 +82,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/digests/${{ matrix.image.name }}
+          path: ${{ runner.temp }}/digests/${{ matrix.image.name }}
           pattern: ${{ matrix.image.name }}-digests-*
           merge-multiple: true
       - name: Set up Docker Buildx
@@ -104,7 +102,7 @@ jobs:
           username: ${{ secrets.STORM_CI_DOCKER_USERNAME }}
           password: ${{ secrets.STORM_CI_DOCKER_TOKEN }}
       - name: Create manifest list and push
-        working-directory: /tmp/digests/${{ matrix.image.name }}
+        working-directory: ${{ runner.temp }}/digests/${{ matrix.image.name }}
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json}}') \
             $(printf '${{ env.IMAGE }}@sha256:%s ' *)


### PR DESCRIPTION
Github supports a Linux ARM runner now and we can build natively under ARM instead of using QEMU.

For the base images this reduces the build time from 15 minutes to 4 minutes.