### PR TITLE
Bumped versions of dependencies

### DIFF
--- a/doc/new_release.md
+++ b/doc/new_release.md
@@ -10,6 +10,12 @@ The following steps should be performed after releasing a new Storm version.
      Also create Docker images for the `stable` version.
 
 3. Create storm-dependencies
+   * Update the versions of the dependencies used in `storm-dependencies/Dockerfile`:
+      * [MathSAT](https://mathsat.fbk.eu/download.html)
+      * [Spot](https://spot.lre.epita.fr/install.html)
+      * [Soplex](https://soplex.zib.de/)
+      * [Gurobi](https://github.com/Gurobi/docker-optimizer/tree/master)
+      * [Carl-storm](https://github.com/moves-rwth/carl-storm/releases) is automatically updated by using the `stable` version.
    * Trigger the action [Build base with dependencies](https://github.com/moves-rwth/docker-storm/actions/workflows/dependencies.yml) in the CI to create Docker images for [storm-dependencies](https://hub.docker.com/r/movesrwth/storm-dependencies/).
 
 4. Create Storm

--- a/storm-dependencies/Dockerfile
+++ b/storm-dependencies/Dockerfile
@@ -20,9 +20,9 @@ ARG no_threads=2
 
 # Specify library versions
 ARG MATHSAT_VERSION=5.6.11
-ARG SPOT_VERSION=2.13.1
-ARG SOPLEX_VERSION=714
-ARG GUROBI_VERSION=12.0.2
+ARG SPOT_VERSION=2.14.1
+ARG SOPLEX_VERSION=715
+ARG GUROBI_VERSION=12.0.3
 ARG GUROBI_SHORT_VERSION=12.0
 
 # Carl-storm is already installed in the base image
@@ -41,15 +41,9 @@ RUN apt-get -y update \
 
 # Install Spot
 ##############
-# Based on https://gitlab.lre.epita.fr/spot/spot/-/issues/544#note_29198
-#RUN wget -q -O - https://www.lrde.epita.fr/repo/debian.gpg | apt-key add - \
-#    && echo 'deb [trusted=true] https://download.opensuse.org/repositories/home:/adl/xUbuntu_22.04/ ./' >/etc/apt/sources.list \
-#    && apt-get update \
-#    && apt-get install -y libspot-dev
-
 # Manual installation
 WORKDIR /opt/
-RUN curl -L -o spot.tar.gz http://www.lre.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz \
+RUN curl -L -o spot.tar.gz http://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz \
     && tar -xzf spot.tar.gz \
     && rm spot.tar.gz \
     && cd spot-${SPOT_VERSION} \
@@ -63,9 +57,14 @@ RUN curl -L -o spot.tar.gz http://www.lre.epita.fr/dload/spot/spot-${SPOT_VERSIO
 # Install MathSAT
 #################
 WORKDIR /opt/
-RUN curl -L -o mathsat5.tar.gz "https://mathsat.fbk.eu/release/mathsat-${MATHSAT_VERSION}-linux-x86_64.tar.gz" \
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        export MATHSAT_PLATFORM="aarch64"; \
+    else \
+        export MATHSAT_PLATFORM="x86_64"; \
+    fi \
+    && curl -L -o mathsat5.tar.gz "https://mathsat.fbk.eu/release/mathsat-${MATHSAT_VERSION}-linux-${MATHSAT_PLATFORM}-reentrant.tar.gz" \
     && tar -xzf mathsat5.tar.gz \
-    && mv mathsat-${MATHSAT_VERSION}-linux-x86_64 mathsat5 \
+    && mv mathsat-${MATHSAT_VERSION}-linux-${MATHSAT_PLATFORM}-reentrant mathsat5 \
     && rm mathsat5.tar.gz
 ENV MATHSAT_ROOT=/opt/mathsat5
 


### PR DESCRIPTION
- Updated Spot, Soplex and Gurobi
- Use reentrant version of MathSAT which is supported on x86_64 and aarch64 