### PR TITLE
Storm-dependencies is not dependent on carl-storm anymore

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -20,11 +20,7 @@ jobs:
       matrix:
         image:
           - {name: "latest",
-             baseImg: "movesrwth/carl-storm:stable",
-             file: "storm-dependencies/Dockerfile"
-            }
-          - {name: "latest-debug",
-             baseImg: "movesrwth/carl-storm:stable-debug",
+             baseImg: "movesrwth/storm-basesystem:latest",
              file: "storm-dependencies/Dockerfile"
             }
         platform:
@@ -87,7 +83,6 @@ jobs:
         image:
           # Must be the same as above
           - {name: "latest"}
-          - {name: "latest-debug"}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v5

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docker containers can be automatically generated via [Github Actions](https://gi
 
 ## File structure
 - [storm-basesystem](storm-basesystem): Dockerfile and build script for the Linux base images with the dependencies required by Storm.
-- [storm-dependencies](storm-dependencies): Dockerfile and build script preparing the dependencies for Storm (carl-storm, Spot, MathSAT, SoPlex, etc.)
+- [storm-dependencies](storm-dependencies): Dockerfile and build script preparing the dependencies for Storm (Spot, MathSAT, SoPlex, etc.)
 - [doc](doc): General documentation, for example on building Docker containers for new releases.
 
 ## Configuration options

--- a/doc/new_release.md
+++ b/doc/new_release.md
@@ -1,27 +1,14 @@
-The following steps should be performed after releasing a new Storm version.
+The following steps should be performed to update the Docker images.
 
-1. Update storm-basesystem
-   * Add new versions of Ubuntu and Debian as base images to the CI configuration file `.github/workflows/basesystem.yml`. Make sure to add the same names also in the merge step.
-   * Remove old versions of Ubuntu and Debian which are not supported anymore from the same configuration file.
-   * Trigger the action [Build basesystem](https://github.com/moves-rwth/docker-storm/actions/workflows/basesystem.yml) in the CI to create Docker images for [storm-basesystem](https://hub.docker.com/r/movesrwth/storm-basesystem/).
+## Update storm-basesystem
+* Add new versions of Ubuntu and Debian as base images to the CI configuration file `.github/workflows/basesystem.yml`. Make sure to add the same names also in the merge step.
+* Remove old versions of Ubuntu and Debian which are not supported anymore from the same configuration file.
+* Trigger the action [Build basesystem](https://github.com/moves-rwth/docker-storm/actions/workflows/basesystem.yml) in the CI to create Docker images for [storm-basesystem](https://hub.docker.com/r/movesrwth/storm-basesystem/).
 
-2. Create carl-storm
-   * Trigger the action [Release Docker](https://github.com/moves-rwth/carl-storm/actions/workflows/release_docker.yml) from the right tag/branch with the right version tag in the CI to create Docker images for [carl-storm](https://hub.docker.com/r/movesrwth/carl-storm/).
-     Also create Docker images for the `stable` version.
-
-3. Create storm-dependencies
-   * Update the versions of the dependencies used in `storm-dependencies/Dockerfile`:
-      * [MathSAT](https://mathsat.fbk.eu/download.html)
-      * [Spot](https://spot.lre.epita.fr/install.html)
-      * [Soplex](https://soplex.zib.de/)
-      * [Gurobi](https://github.com/Gurobi/docker-optimizer/tree/master)
-      * [Carl-storm](https://github.com/moves-rwth/carl-storm/releases) is automatically updated by using the `stable` version.
-   * Trigger the action [Build base with dependencies](https://github.com/moves-rwth/docker-storm/actions/workflows/dependencies.yml) in the CI to create Docker images for [storm-dependencies](https://hub.docker.com/r/movesrwth/storm-dependencies/).
-
-4. Create Storm
-   * Trigger the action [Release Docker](https://github.com/moves-rwth/storm/actions/workflows/release_docker.yml) from the right tag/branch with the right version tag in the CI to create Docker images for [storm](https://hub.docker.com/r/movesrwth/storm/).
-     Also create Docker images for the `stable` version.
-
-5. Create stormpy
-   * Trigger the action [Release Docker](https://github.com/moves-rwth/stormpy/actions/workflows/release_docker.yml) from the right tag/branch with the right version tag in the CI to create Docker images for [stormpy](https://hub.docker.com/r/movesrwth/stormpy/).
-     Also create Docker images for the `stable` version.
+## Create storm-dependencies
+* Update the versions of the dependencies used in `storm-dependencies/Dockerfile`:
+  * [MathSAT](https://mathsat.fbk.eu/download.html)
+  * [Spot](https://spot.lre.epita.fr/install.html)
+  * [Soplex](https://soplex.zib.de/)
+  * [Gurobi](https://github.com/Gurobi/docker-optimizer/tree/master)
+* Trigger the action [Build base with dependencies](https://github.com/moves-rwth/docker-storm/actions/workflows/dependencies.yml) in the CI to create Docker images for [storm-dependencies](https://hub.docker.com/r/movesrwth/storm-dependencies/).

--- a/storm-dependencies/Dockerfile
+++ b/storm-dependencies/Dockerfile
@@ -6,7 +6,7 @@
 # --build-arg BASE_IMAGE=<new_base_image>
 
 # Set base image
-ARG BASE_IMAGE=movesrwth/carl-storm:stable
+ARG BASE_IMAGE=movesrwth/storm-basesystem:latest
 FROM $BASE_IMAGE
 ARG TARGETPLATFORM
 LABEL org.opencontainers.image.authors="dev@stormchecker.org"
@@ -24,8 +24,6 @@ ARG SPOT_VERSION=2.14.1
 ARG SOPLEX_VERSION=715
 ARG GUROBI_VERSION=12.0.3
 ARG GUROBI_SHORT_VERSION=12.0
-
-# Carl-storm is already installed in the base image
 
 
 # Install additional packages


### PR DESCRIPTION
As a result, the Docker image `storm-dependencies:latest-debug` will be discontinued and only `storm-dependencies:latest` will remain.